### PR TITLE
Eliminating --no-site-packages from every call of virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 .idea/*
+.vscode
+build
+dist

--- a/pebble_tool/sdk/manager.py
+++ b/pebble_tool/sdk/manager.py
@@ -114,7 +114,7 @@ class SDKManager(object):
                 t.extractall(path)
             virtualenv_path = os.path.join(path, ".env")
             print("Preparing virtualenv... (this may take a while)")
-            subprocess.check_call([sys.executable, "-m", "virtualenv", virtualenv_path, "--no-site-packages"])
+            subprocess.check_call([sys.executable, "-m", "virtualenv", virtualenv_path])
             print("Installing dependencies...")
             subprocess.check_call([os.path.join(virtualenv_path, "bin", "python"), "-m", "pip", "install", "-r",
                                    os.path.join(path, "sdk-core", "requirements.txt")],
@@ -241,7 +241,7 @@ subprocess.call([sys.executable, {}] + sys.argv[1:])
             os.symlink(os.path.join(build_path, 'qemu_spi_flash.bin'),
                        os.path.join(pebble_path, platform, 'qemu', 'qemu_spi_flash.bin'))
 
-        os.symlink(os.path.join(sdk_path, 'common/'), 
+        os.symlink(os.path.join(sdk_path, 'common/'),
                    os.path.join(pebble_path, 'common'))
 
         with open(os.path.join(dest_path, 'manifest.json'), 'w') as f:
@@ -253,7 +253,7 @@ subprocess.call([sys.executable, {}] + sys.argv[1:])
             }, f)
 
         print("Preparing virtualenv... (this may take a while)")
-        subprocess.check_call([sys.executable, "-m", "virtualenv", env_path, "--no-site-packages"])
+        subprocess.check_call([sys.executable, "-m", "virtualenv", env_path])
         print("Installing dependencies...")
         print("This may fail installing Pillow==2.0.0. In that case, question why we still force 2.0.0 anyway.")
         if sys.platform.startswith('darwin'):

--- a/pebble_tool/version.py
+++ b/pebble_tool/version.py
@@ -1,5 +1,5 @@
 version_base = (4, 6, 0)
-version_suffix = 'rc1'
+version_suffix = 'rc3'
 
 if version_suffix is None:
     __version_info__ = version_base


### PR DESCRIPTION
With new versions of python this breaks everywhere as --no-site-packages is the default