### PR TITLE
Working Python 2.7 support under Microsoft Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,11 @@ To install, from a checkout, issue:
 
     python -m pip install -r requirements.txt
 
+or:
+
+    python setup.py develop
+    python setup.py install
+
+
 Definitely works with Python 2.7.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Pebble build tool
+
+To install, from a checkout, issue:
+
+    python -m pip install -r requirements.txt
+
+Definitely works with Python 2.7.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pebble build tool
+# Pebble Tool
 
 To install, from a checkout, issue:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-#libpebble2==0.0.28
-git+https://github.com/pebble-dev/libpebble2.git@685cd9841e647b48609ce904a87540019390b3be#egg=libpebble2
+libpebble2==0.0.28
 enum34==1.0.4
 httplib2==0.19.0
 oauth2client==1.4.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 libpebble2==0.0.28
 enum34==1.0.4
+pyparsing==2.4.7
 httplib2==0.19.0
 oauth2client==1.4.12
 progressbar2==2.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-libpebble2==0.0.26
+#libpebble2==0.0.28
+git+https://github.com/pebble-dev/libpebble2.git@685cd9841e647b48609ce904a87540019390b3be#egg=libpebble2
 enum34==1.0.4
 httplib2==0.19.0
 oauth2client==1.4.12
@@ -16,3 +17,4 @@ websocket-client==0.32.0
 wheel==0.24.0
 colorama==0.3.3
 packaging==16.7
+pyreadline==2.1

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requires = [
     'wheel==0.24.0',
     'colorama==0.3.3',
     'packaging==16.7',
+    'pyreadline==2.1',
 ]
 
 if sys.version_info < (3, 4, 0):

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.26',
-    'httplib2==0.9.1',
+    'pyparsing==2.4.7',
+    'libpebble2==0.0.28',
+    'httplib2==0.19.0',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',
     'pyasn1==0.1.8',


### PR DESCRIPTION
* Added a bare bones readme
* Use the newer version of libpebble2 (0.0.28) from Rebble GitHub repo, rather than what appears to be unmaintained PyPi version (appears because the links in the page at https://pypi.org/project/libpebble2/ are to the old unmaintained repo, not the current https://github.com/pebble-dev/pebble-tool/ one)

Tested with:

    Python 2.7.10 (default, May 23 2015, 09:40:32) [MSC v.1500 32 bit (Intel)] on win32

Ready for 2nd review 2023-07-22 (12:11 Pacific time)