### PR TITLE
Fix 128kb url limit in open_config_page

### DIFF
--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -8,21 +8,22 @@ import socket
 import time
 from six.moves.urllib import parse as urlparse
 import webbrowser
-
+import tempfile
 from .phone_sensor import SENSOR_PAGE_HTML
 
 
 logger = logging.getLogger("pebble_tool.util.browser")
-
 class BrowserController(object):
     def __init__(self):
         self.port = None
-
     def open_config_page(self, url, callback):
         self.port = port = self._choose_port()
         url = self.url_append_params(url, {'return_to': 'http://localhost:{}/close?'.format(port)})
-        webbrowser.open_new(url)
-        self.serve_page(port, callback)
+        with tempfile.NamedTemporaryFile(suffix = '.html') as tmp:
+          tmp.write('<meta http-equiv="refresh" content="0;url={}"/>'.format(url))
+          tmp.flush()
+          webbrowser.open(tmp.name)
+          self.serve_page(port, callback)
 
     def serve_page(self, port, callback):
         # This is an array so AppConfigHandler doesn't create an instance variable when trying to set the state to False


### PR DESCRIPTION
There is a 128kb hard coded limit by default in the linux kernel for the max length of a single argument (MAX_ARG_STRLEN).

The `open_config_page()` function in the `BrowserController` object can run into this if the generated app configuration URL is sufficiently large. This is because the webbrowser module will just pass the provided URL as a command line argument to the selected browser.

This can be worked around by writing the url out to a temporary file instead and wrapping it in a client side redirect (`<meta http-equiv="refresh" content="0;url={}/>`).

I wrote a small script to show the error and prove my solution:
```python
from pebble_tool.util.browser import BrowserController

def handle_config_close(query):
  print(query)

with open("url.txt") as f:
  test_url = f.read()
browser = BrowserController()
browser.open_config_page(test_url, handle_config_close)
```

The contents of the test url (`url.txt`) are ~145kb large:
[url.txt](https://github.com/pebble-dev/pebble-tool/files/10787813/url.txt)

Output before changing `open_config_page`:
```bash
❯ python2 browser_test.py
Traceback (most recent call last):
  File "browser_test.py", line 9, in <module>
    browser.open_config_page(test_url, handle_config_close)
  File "/home/kennedn/Projects/pebble-tool/pebble_tool/util/browser.py", line 24, in open_config_page
    webbrowser.open_new(url)
  File "/usr/lib/python2.7/webbrowser.py", line 66, in open_new
    return open(url, 1)
  File "/usr/lib/python2.7/webbrowser.py", line 61, in open
    if browser.open(url, new, autoraise):
  File "/usr/lib/python2.7/webbrowser.py", line 275, in open
    success = self._invoke(args, True, autoraise)
  File "/usr/lib/python2.7/webbrowser.py", line 238, in _invoke
    stderr=inout, preexec_fn=setsid)
  File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
OSError: [Errno 7] Argument list too long
```

Output after switching over to the tempfile method:
```python
❯ python2 browser_test.py

```
 The browser then proceeds to open the configuration page:
 
![Screenshot from 2023-02-20 21-13-01](https://user-images.githubusercontent.com/8060657/220199715-5048d78c-e40d-4b05-8518-69456afeed5a.png)
