### PR TITLE
Added README. use latest libpebble2, sync httplib2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Pebble Tool
+
+Available from Rebble project page https://github.com/pebble-dev/pebble-tool/
+
+Definitely works with Python 2.7.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-libpebble2==0.0.26
+libpebble2==0.0.28
 enum34==1.0.4
 httplib2==0.19.0
 oauth2client==1.4.12

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.26',
-    'httplib2==0.9.1',
+    'libpebble2==0.0.28',
+    'httplib2==0.19.0',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',
     'pyasn1==0.1.8',


### PR DESCRIPTION
The libpebble2 used was not the latest.

httplib2 version in setup.py was different to requirements.txt.