### PR TITLE
Working native Windows instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 Available from Rebble project page https://github.com/pebble-dev/pebble-tool/
 
 Definitely works with Python 2.7.
+
+## Windows note
+
+Windows is NOT a supported platform for Pebble (outside of WSL).
+
+However you can get debug trace on native Windows using Python 2.7
+by checking out the code and issuing:
+
+    python -m pip install -r requirements_py27win.txt
+
+Debug trace can be accessed via:
+
+    python pebble.py logs --phone IP_ADDRESS_HERE
+
+Alternatively `setup.py` can be called with the usual `develop` or `install`
+parameter.

--- a/requirements_py27win.txt
+++ b/requirements_py27win.txt
@@ -1,0 +1,3 @@
+pyparsing==2.4.7
+pyreadline==2.1
+-r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ requires = [
 
 if sys.version_info < (3, 4, 0):
     requires.append('enum34==1.0.4')
+if sys.version_info < (3, 0) and sys.platform.startswith('win'):
+    requires.insert(0, 'pyparsing==2.4.7')
+    requires.insert(0, 'pyreadline==2.1')
 
 __version__ = None  # Overwritten by executing version.py.
 with open('pebble_tool/version.py') as f:


### PR DESCRIPTION
NOTE allows "logs" operation, native Windows support is not a goal.